### PR TITLE
Remove ability to log all script users IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ This is a **fork** of the [original script](https://github.com/vernette/ipregion
 ## Usage
 Run script:
 ```bash
-bash <(wget -qO- ipregion.xyz)
-```
-Or run **directly** from GitHub:
-```bash
 bash <(wget -qO- https://raw.githubusercontent.com/Davoyan/ipregion/main/ipregion.sh)
 ```
 


### PR DESCRIPTION
Using a custom URL instead of a direct GitHub link allows the host to log every script download and the source IP address. It also introduces a security risk: the server hosting the custom URL (ipregion.xyz) could be compromised, and the script replaced with a malicious one. This is not possible when using a direct GitHub link