### PR TITLE
fix: resolve IP detection, DoH validation, and legend crash (empty list issue)

### DIFF
--- a/ipregion.sh
+++ b/ipregion.sh
@@ -795,7 +795,7 @@ check_ip_support() {
   local version="$1"
   log "$LOG_INFO" "Checking for IPv${version} support"
 
-  if ip -${version} addr show scope global 2>/dev/null | grep -q "inet${version}"; then
+  if ip -${version} addr show scope global 2>/dev/null | grep -q "inet${version//4/ }"; then
     log "$LOG_INFO" "IPv${version} is supported"
     return 0
   fi
@@ -1568,6 +1568,7 @@ print_legend() {
     echo "$header"
 
     while read -r code; do
+      [[ -z "$code" ]] && continue
       local country ipv4_num ipv6_num ipv4_str ipv6_str
       country="${COUNTRY_NAMES[$code]:-Unknown}"
 
@@ -2182,28 +2183,16 @@ check_doh() {
         "AdGuard|https://94.140.14.140/dns-query|https://94.140.14.140/dns-query"
     )
 
-    local curl_opts=(-sS --max-time 5 --connect-timeout 2 --retry 1 --retry-connrefused \
-                     -H "accept: application/dns-json")
+    local curl_opts=(-s --max-time 5 --connect-timeout 2 -o /dev/null)
 
-    local entry name doh_url test_url url response
+    local entry name doh_url test_url
 
     for entry in "${resolvers[@]}"; do
         IFS="|" read -r name doh_url test_url <<<"$entry"
-        url="${test_url}?name=${test_domain}&type=A"
 
-        response="$(curl "${curl_opts[@]}" "$url" 2>/dev/null)"
-
-        if command -v jq >/dev/null 2>&1; then
-            if printf '%s' "$response" | jq -e '.Status == 0 and (.Answer | length > 0)' >/dev/null 2>&1; then
-                SELECTED_DOH_URL="--doh-url ${doh_url}"
-                return 0
-            fi
-        else
-            if echo "$response" | grep -q '"Status"[[:space:]]*:[[:space:]]*0' && \
-               echo "$response" | grep -q '"Answer"'; then
-                SELECTED_DOH_URL="--doh-url ${doh_url}"
-                return 0
-            fi
+        if curl "${curl_opts[@]}" --doh-url "$doh_url" "https://$test_domain/" 2>/dev/null; then
+            SELECTED_DOH_URL="--doh-url ${doh_url}"
+            return 0
         fi
     done
 


### PR DESCRIPTION
(detailed initial issue desc in issues in repo https://github.com/uyriq/ipregion-fix-emty-list/issues/1)

Three bugs prevented the script from producing any output when run on a system with a standard single-stack IPv4 setup.

**1. check_ip_support: wrong grep pattern for IPv4 (line ~798)**

`ip -4 addr show` outputs lines starting with `inet` (not `inet4`), so `grep -q "inet${version}"` was matching `inet4` — a string that never appears. IPv4 was always reported as unsupported, leaving `EXTERNAL_IPV4` empty and causing all service checks to be skipped.

  Before: grep -q "inet${version}"       # looks for "inet4" / "inet6"
  After:  grep -q "inet${version//4/ }"  # looks for "inet " / "inet6"

**2. check_doh: validation didn't test the actual --doh-url mechanism**

The old implementation tested DoH by fetching the resolver endpoint directly (`curl https://1.1.1.1/dns-query?name=...`). This succeeded even when the DoH server was unreachable via TCP on the local network. As a result, `SELECTED_DOH_URL` was set to `--doh-url <unreachable>`, which broke DNS resolution in every subsequent `make_request` call, returning empty responses for all services.

The fix validates DoH by actually using `--doh-url` to resolve a real domain, mirroring exactly how it will be used in production requests. If no resolver works, `SELECTED_DOH_URL` is left empty.

  Before: curl https://<doh-endpoint>?name=...  (tests raw reachability)
  After:  curl --doh-url <doh-endpoint> https://www.google.com/  (tests functional use)

**3. print_legend: bad array subscript crash on empty results**

When `EXTERNAL_IPV4` was empty (due to bug #1), the `$codes` variable was an empty string. `while read -r code; do ... done <<< "$codes"` still executes one iteration with `code=""`. Bash associative arrays reject empty-string subscripts with "bad array subscript", crashing the legend rendering.

Added an early-continue guard at the top of the loop:
  [[ -z "$code" ]] && continue

NB: code was generated mostly with Sonnet 4.6

before fix state
<img width="859" height="628" alt="Screenshot from 2026-04-26 16-25-25" src="https://github.com/user-attachments/assets/f8b38e24-7377-4083-bd76-530c1526d3bf" />

after a85abbf as expected